### PR TITLE
fix warning that crash continuous integration builds

### DIFF
--- a/org.osate.importer.lattix/build.properties
+++ b/org.osate.importer.lattix/build.properties
@@ -4,7 +4,6 @@ bin.includes = META-INF/,\
                .,\
                build.properties,\
                plugin.xml,\
-               bin/,\
                lib/jxl.jar,\
                plugin.properties
 jars.compile.order = .


### PR DESCRIPTION
Fix useless include that crashes continuous integration builds.

Sébastien Gardoll
