### PR TITLE
Add method to return power report object instead of always printing it

### DIFF
--- a/org.osate.analysis.resource.budgets/src/org/osate/analysis/resource/budgets/actions/DoPowerAnalysis.java
+++ b/org.osate.analysis.resource.budgets/src/org/osate/analysis/resource/budgets/actions/DoPowerAnalysis.java
@@ -65,18 +65,22 @@ public final class DoPowerAnalysis extends AbstractInstanceOrDeclarativeModelRea
 		currentInstance = this;
 	}
 
+	@Override
 	protected Bundle getBundle() {
 		return ResourceBudgetPlugin.getDefault().getBundle();
 	}
 
+	@Override
 	public String getMarkerType() {
 		return "org.osate.analysis.resource.budgets.PowerAnalysisMarker";
 	}
 
+	@Override
 	protected String getActionName() {
 		return "Analyze power consumption";
 	}
 
+	@Override
 	protected void initPropertyReferences() {
 	}
 
@@ -115,15 +119,15 @@ public final class DoPowerAnalysis extends AbstractInstanceOrDeclarativeModelRea
 		excelExport.save();
 		return true;
 	};
-	
+
 	public void setErrManager() {
 		this.errManager = new AnalysisErrorReporterManager(this.getAnalysisErrorReporterFactory());
 	}
-	
+
 	public void setSummaryReport() {
 		this.summaryReport = new StringBuffer();
 	}
-	
+
 	public void saveReport() {
 		this.getCSVLog().saveToFile();
 	}
@@ -132,4 +136,8 @@ public final class DoPowerAnalysis extends AbstractInstanceOrDeclarativeModelRea
 		actionBody(monitor, root);
 	}
 
+	public Report invokeAndGetReport(IProgressMonitor monitor, SystemInstance root) {
+		actionBody(monitor, root);
+		return powerReport;
+	}
 }


### PR DESCRIPTION
The GTSE plugin needs access to the report, so rather than have it get written to disk and then read back in I added a method to just return the report object. Also, I ran the code formatter on the DoPowerAnalysis class, so it cleaned it up / added some annotations.