### PR TITLE
Fixes #792.

### DIFF
--- a/org.osate.analysis.flows/src/org/osate/analysis/flows/FlowLatencyLogic.java
+++ b/org.osate.analysis.flows/src/org/osate/analysis/flows/FlowLatencyLogic.java
@@ -22,6 +22,13 @@ public class FlowLatencyLogic {
 			FlowLatencyLogicConnection.mapConnectionInstance(etef, flowElementInstance, entry);
 		}
 
+		if (flowElementInstance instanceof EndToEndFlowInstance) {
+
+			for (FlowElementInstance fei : ((EndToEndFlowInstance) flowElementInstance).getFlowElements()) {
+				FlowLatencyLogic.mapFlowElementInstance(etef, fei, entry);
+			}
+		}
+
 	}
 
 }


### PR DESCRIPTION
FlowLatencyLogic did not handle the case of and ETEFinstance reference
as ETEFElement. We now recurse on the referenced ETEF.