### PR TITLE
Resultreport usage in latency analysis

### DIFF
--- a/org.osate.analysis.flows.tests/src/org/osate/analysis/flows/tests/CombinedETEFTest.xtend
+++ b/org.osate.analysis.flows.tests/src/org/osate/analysis/flows/tests/CombinedETEFTest.xtend
@@ -49,6 +49,12 @@ class CombinedETEFTest extends OsateTest {
 		val file = workspaceRoot.getFile(new Path(uri.toPlatformString(true)))
 		val actual = Files.readStreamIntoString(file.contents)
 		assertEquals('error', expected.trim, actual.trim)
+		// read result
+		val uriresult = URI.createURI(
+			resourceRoot + "/instances/reports/latency/CombinedETEF_Test_Impl_Instance__latency_AS-MF-DL-EQ.result")
+		val fileresult = workspaceRoot.getFile(new Path(uriresult.toPlatformString(true)))
+		val actualresult = Files.readStreamIntoString(fileresult.contents)
+		assertEquals('error', expectedresult.trim, actualresult.trim)
 	}
 
 	val combinedETEFText = '''
@@ -162,5 +168,430 @@ ERROR,Maximum actual latency total 40.0ms exceeds expected maximum end to end la
 
 
 
+
+
+
 	'''
+
+	val expectedresult = '''
+<?xml version="1.0" encoding="ASCII"?>
+<result:Result xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:result="http://www.osate.org/result/Result" analysis="latencyreport">
+  <sourceReference href="../../CombinedETEF_Test_Impl_Instance.aaxl2#/"/>
+  <subResults analysis="a_b">
+    <sourceReference href="../../CombinedETEF_Test_Impl_Instance.aaxl2#//@endToEndFlow.0"/>
+    <values xsi:type="result:StringValue" value="Latency analysis for end-to-end flow 'a_b' of system 'Test.Impl' with preference settings AS-MF-DL-EQ"/>
+    <values xsi:type="result:RealValue" value="20.0"/>
+    <values xsi:type="result:RealValue" value="20.0"/>
+    <values xsi:type="result:RealValue" value="20.0"/>
+    <values xsi:type="result:RealValue" value="20.0"/>
+    <values xsi:type="result:RealValue"/>
+    <values xsi:type="result:RealValue"/>
+    <contributors>
+      <sourceReference href="../../CombinedETEF_Test_Impl_Instance.aaxl2#//@componentInstance.0"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:StringValue" value="FIRST_SAMPLED"/>
+      <values xsi:type="result:StringValue" value="FIRST_SAMPLED"/>
+      <values xsi:type="result:StringValue" value="SYNCUNKNOWN"/>
+      <issues issueType="INFO" message="Initial 0.0ms sampling latency not added" diagnostic="">
+        <sourceReference href="../../CombinedETEF_Test_Impl_Instance.aaxl2#//@componentInstance.0"/>
+      </issues>
+    </contributors>
+    <contributors>
+      <sourceReference href="../../CombinedETEF_Test_Impl_Instance.aaxl2#//@componentInstance.0"/>
+      <values xsi:type="result:RealValue" value="10.0"/>
+      <values xsi:type="result:RealValue" value="10.0"/>
+      <values xsi:type="result:RealValue" value="10.0"/>
+      <values xsi:type="result:RealValue" value="10.0"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue" value="10.0"/>
+      <values xsi:type="result:RealValue" value="10.0"/>
+      <values xsi:type="result:RealValue" value="10.0"/>
+      <values xsi:type="result:StringValue" value="SPECIFIED"/>
+      <values xsi:type="result:StringValue" value="SPECIFIED"/>
+      <values xsi:type="result:StringValue" value="SYNCUNKNOWN"/>
+    </contributors>
+    <contributors>
+      <sourceReference href="../../CombinedETEF_Test_Impl_Instance.aaxl2#//@connectionInstance.0"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue" value="10.0"/>
+      <values xsi:type="result:RealValue" value="10.0"/>
+      <values xsi:type="result:RealValue" value="10.0"/>
+      <values xsi:type="result:StringValue" value="UNKNOWN"/>
+      <values xsi:type="result:StringValue" value="UNKNOWN"/>
+      <values xsi:type="result:StringValue" value="SYNCUNKNOWN"/>
+    </contributors>
+    <contributors>
+      <sourceReference href="../../CombinedETEF_Test_Impl_Instance.aaxl2#//@componentInstance.1"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue" value="10.0"/>
+      <values xsi:type="result:RealValue" value="10.0"/>
+      <values xsi:type="result:RealValue" value="10.0"/>
+      <values xsi:type="result:StringValue" value="SAMPLED"/>
+      <values xsi:type="result:StringValue" value="SAMPLED"/>
+      <values xsi:type="result:StringValue" value="SYNCUNKNOWN"/>
+      <issues issueType="INFO" message="Best case 0 ms worst case 0.0ms (period) sampling delay" diagnostic="">
+        <sourceReference href="../../CombinedETEF_Test_Impl_Instance.aaxl2#//@componentInstance.1"/>
+      </issues>
+    </contributors>
+    <contributors>
+      <sourceReference href="../../CombinedETEF_Test_Impl_Instance.aaxl2#//@componentInstance.1"/>
+      <values xsi:type="result:RealValue" value="10.0"/>
+      <values xsi:type="result:RealValue" value="10.0"/>
+      <values xsi:type="result:RealValue" value="10.0"/>
+      <values xsi:type="result:RealValue" value="10.0"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue" value="20.0"/>
+      <values xsi:type="result:RealValue" value="20.0"/>
+      <values xsi:type="result:RealValue" value="20.0"/>
+      <values xsi:type="result:StringValue" value="SPECIFIED"/>
+      <values xsi:type="result:StringValue" value="SPECIFIED"/>
+      <values xsi:type="result:StringValue" value="SYNCUNKNOWN"/>
+    </contributors>
+  </subResults>
+  <subResults analysis="c_d">
+    <sourceReference href="../../CombinedETEF_Test_Impl_Instance.aaxl2#//@endToEndFlow.1"/>
+    <values xsi:type="result:StringValue" value="Latency analysis for end-to-end flow 'c_d' of system 'Test.Impl' with preference settings AS-MF-DL-EQ"/>
+    <values xsi:type="result:RealValue" value="20.0"/>
+    <values xsi:type="result:RealValue" value="20.0"/>
+    <values xsi:type="result:RealValue" value="20.0"/>
+    <values xsi:type="result:RealValue" value="20.0"/>
+    <values xsi:type="result:RealValue"/>
+    <values xsi:type="result:RealValue"/>
+    <contributors>
+      <sourceReference href="../../CombinedETEF_Test_Impl_Instance.aaxl2#//@componentInstance.2"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:StringValue" value="FIRST_SAMPLED"/>
+      <values xsi:type="result:StringValue" value="FIRST_SAMPLED"/>
+      <values xsi:type="result:StringValue" value="SYNCUNKNOWN"/>
+      <issues issueType="INFO" message="Initial 0.0ms sampling latency not added" diagnostic="">
+        <sourceReference href="../../CombinedETEF_Test_Impl_Instance.aaxl2#//@componentInstance.2"/>
+      </issues>
+    </contributors>
+    <contributors>
+      <sourceReference href="../../CombinedETEF_Test_Impl_Instance.aaxl2#//@componentInstance.2"/>
+      <values xsi:type="result:RealValue" value="10.0"/>
+      <values xsi:type="result:RealValue" value="10.0"/>
+      <values xsi:type="result:RealValue" value="10.0"/>
+      <values xsi:type="result:RealValue" value="10.0"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue" value="10.0"/>
+      <values xsi:type="result:RealValue" value="10.0"/>
+      <values xsi:type="result:RealValue" value="10.0"/>
+      <values xsi:type="result:StringValue" value="SPECIFIED"/>
+      <values xsi:type="result:StringValue" value="SPECIFIED"/>
+      <values xsi:type="result:StringValue" value="SYNCUNKNOWN"/>
+    </contributors>
+    <contributors>
+      <sourceReference href="../../CombinedETEF_Test_Impl_Instance.aaxl2#//@connectionInstance.2"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue" value="10.0"/>
+      <values xsi:type="result:RealValue" value="10.0"/>
+      <values xsi:type="result:RealValue" value="10.0"/>
+      <values xsi:type="result:StringValue" value="UNKNOWN"/>
+      <values xsi:type="result:StringValue" value="UNKNOWN"/>
+      <values xsi:type="result:StringValue" value="SYNCUNKNOWN"/>
+    </contributors>
+    <contributors>
+      <sourceReference href="../../CombinedETEF_Test_Impl_Instance.aaxl2#//@componentInstance.3"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue" value="10.0"/>
+      <values xsi:type="result:RealValue" value="10.0"/>
+      <values xsi:type="result:RealValue" value="10.0"/>
+      <values xsi:type="result:StringValue" value="SAMPLED"/>
+      <values xsi:type="result:StringValue" value="SAMPLED"/>
+      <values xsi:type="result:StringValue" value="SYNCUNKNOWN"/>
+      <issues issueType="INFO" message="Best case 0 ms worst case 0.0ms (period) sampling delay" diagnostic="">
+        <sourceReference href="../../CombinedETEF_Test_Impl_Instance.aaxl2#//@componentInstance.3"/>
+      </issues>
+    </contributors>
+    <contributors>
+      <sourceReference href="../../CombinedETEF_Test_Impl_Instance.aaxl2#//@componentInstance.3"/>
+      <values xsi:type="result:RealValue" value="10.0"/>
+      <values xsi:type="result:RealValue" value="10.0"/>
+      <values xsi:type="result:RealValue" value="10.0"/>
+      <values xsi:type="result:RealValue" value="10.0"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue" value="20.0"/>
+      <values xsi:type="result:RealValue" value="20.0"/>
+      <values xsi:type="result:RealValue" value="20.0"/>
+      <values xsi:type="result:StringValue" value="SPECIFIED"/>
+      <values xsi:type="result:StringValue" value="SPECIFIED"/>
+      <values xsi:type="result:StringValue" value="SYNCUNKNOWN"/>
+    </contributors>
+  </subResults>
+  <subResults analysis="total">
+    <sourceReference href="../../CombinedETEF_Test_Impl_Instance.aaxl2#//@endToEndFlow.2"/>
+    <values xsi:type="result:StringValue" value="Latency analysis for end-to-end flow 'total' of system 'Test.Impl' with preference settings AS-MF-DL-EQ"/>
+    <values xsi:type="result:RealValue" value="40.0"/>
+    <values xsi:type="result:RealValue" value="40.0"/>
+    <values xsi:type="result:RealValue" value="40.0"/>
+    <values xsi:type="result:RealValue" value="40.0"/>
+    <values xsi:type="result:RealValue" value="20.0"/>
+    <values xsi:type="result:RealValue" value="30.0"/>
+    <contributors>
+      <sourceReference href="../../CombinedETEF_Test_Impl_Instance.aaxl2#//@componentInstance.0"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:StringValue" value="FIRST_SAMPLED"/>
+      <values xsi:type="result:StringValue" value="FIRST_SAMPLED"/>
+      <values xsi:type="result:StringValue" value="SYNCUNKNOWN"/>
+      <issues issueType="INFO" message="Initial 0.0ms sampling latency not added" diagnostic="">
+        <sourceReference href="../../CombinedETEF_Test_Impl_Instance.aaxl2#//@componentInstance.0"/>
+      </issues>
+    </contributors>
+    <contributors>
+      <sourceReference href="../../CombinedETEF_Test_Impl_Instance.aaxl2#//@componentInstance.0"/>
+      <values xsi:type="result:RealValue" value="10.0"/>
+      <values xsi:type="result:RealValue" value="10.0"/>
+      <values xsi:type="result:RealValue" value="10.0"/>
+      <values xsi:type="result:RealValue" value="10.0"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue" value="10.0"/>
+      <values xsi:type="result:RealValue" value="10.0"/>
+      <values xsi:type="result:RealValue" value="10.0"/>
+      <values xsi:type="result:StringValue" value="SPECIFIED"/>
+      <values xsi:type="result:StringValue" value="SPECIFIED"/>
+      <values xsi:type="result:StringValue" value="SYNCUNKNOWN"/>
+    </contributors>
+    <contributors>
+      <sourceReference href="../../CombinedETEF_Test_Impl_Instance.aaxl2#//@connectionInstance.0"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue" value="10.0"/>
+      <values xsi:type="result:RealValue" value="10.0"/>
+      <values xsi:type="result:RealValue" value="10.0"/>
+      <values xsi:type="result:StringValue" value="UNKNOWN"/>
+      <values xsi:type="result:StringValue" value="UNKNOWN"/>
+      <values xsi:type="result:StringValue" value="SYNCUNKNOWN"/>
+    </contributors>
+    <contributors>
+      <sourceReference href="../../CombinedETEF_Test_Impl_Instance.aaxl2#//@componentInstance.1"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue" value="10.0"/>
+      <values xsi:type="result:RealValue" value="10.0"/>
+      <values xsi:type="result:RealValue" value="10.0"/>
+      <values xsi:type="result:StringValue" value="SAMPLED"/>
+      <values xsi:type="result:StringValue" value="SAMPLED"/>
+      <values xsi:type="result:StringValue" value="SYNCUNKNOWN"/>
+      <issues issueType="INFO" message="Best case 0 ms worst case 0.0ms (period) sampling delay" diagnostic="">
+        <sourceReference href="../../CombinedETEF_Test_Impl_Instance.aaxl2#//@componentInstance.1"/>
+      </issues>
+    </contributors>
+    <contributors>
+      <sourceReference href="../../CombinedETEF_Test_Impl_Instance.aaxl2#//@componentInstance.1"/>
+      <values xsi:type="result:RealValue" value="10.0"/>
+      <values xsi:type="result:RealValue" value="10.0"/>
+      <values xsi:type="result:RealValue" value="10.0"/>
+      <values xsi:type="result:RealValue" value="10.0"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue" value="20.0"/>
+      <values xsi:type="result:RealValue" value="20.0"/>
+      <values xsi:type="result:RealValue" value="20.0"/>
+      <values xsi:type="result:StringValue" value="SPECIFIED"/>
+      <values xsi:type="result:StringValue" value="SPECIFIED"/>
+      <values xsi:type="result:StringValue" value="SYNCUNKNOWN"/>
+    </contributors>
+    <contributors>
+      <sourceReference href="../../CombinedETEF_Test_Impl_Instance.aaxl2#//@connectionInstance.1"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue" value="20.0"/>
+      <values xsi:type="result:RealValue" value="20.0"/>
+      <values xsi:type="result:RealValue" value="20.0"/>
+      <values xsi:type="result:StringValue" value="UNKNOWN"/>
+      <values xsi:type="result:StringValue" value="UNKNOWN"/>
+      <values xsi:type="result:StringValue" value="SYNCUNKNOWN"/>
+    </contributors>
+    <contributors>
+      <sourceReference href="../../CombinedETEF_Test_Impl_Instance.aaxl2#//@componentInstance.2"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue" value="20.0"/>
+      <values xsi:type="result:RealValue" value="20.0"/>
+      <values xsi:type="result:RealValue" value="20.0"/>
+      <values xsi:type="result:StringValue" value="SAMPLED"/>
+      <values xsi:type="result:StringValue" value="SAMPLED"/>
+      <values xsi:type="result:StringValue" value="SYNCUNKNOWN"/>
+      <issues issueType="INFO" message="Best case 0 ms worst case 0.0ms (period) sampling delay" diagnostic="">
+        <sourceReference href="../../CombinedETEF_Test_Impl_Instance.aaxl2#//@componentInstance.2"/>
+      </issues>
+    </contributors>
+    <contributors>
+      <sourceReference href="../../CombinedETEF_Test_Impl_Instance.aaxl2#//@componentInstance.2"/>
+      <values xsi:type="result:RealValue" value="10.0"/>
+      <values xsi:type="result:RealValue" value="10.0"/>
+      <values xsi:type="result:RealValue" value="10.0"/>
+      <values xsi:type="result:RealValue" value="10.0"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue" value="30.0"/>
+      <values xsi:type="result:RealValue" value="30.0"/>
+      <values xsi:type="result:RealValue" value="30.0"/>
+      <values xsi:type="result:StringValue" value="SPECIFIED"/>
+      <values xsi:type="result:StringValue" value="SPECIFIED"/>
+      <values xsi:type="result:StringValue" value="SYNCUNKNOWN"/>
+    </contributors>
+    <contributors>
+      <sourceReference href="../../CombinedETEF_Test_Impl_Instance.aaxl2#//@connectionInstance.2"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue" value="30.0"/>
+      <values xsi:type="result:RealValue" value="30.0"/>
+      <values xsi:type="result:RealValue" value="30.0"/>
+      <values xsi:type="result:StringValue" value="UNKNOWN"/>
+      <values xsi:type="result:StringValue" value="UNKNOWN"/>
+      <values xsi:type="result:StringValue" value="SYNCUNKNOWN"/>
+    </contributors>
+    <contributors>
+      <sourceReference href="../../CombinedETEF_Test_Impl_Instance.aaxl2#//@componentInstance.3"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue" value="30.0"/>
+      <values xsi:type="result:RealValue" value="30.0"/>
+      <values xsi:type="result:RealValue" value="30.0"/>
+      <values xsi:type="result:StringValue" value="SAMPLED"/>
+      <values xsi:type="result:StringValue" value="SAMPLED"/>
+      <values xsi:type="result:StringValue" value="SYNCUNKNOWN"/>
+      <issues issueType="INFO" message="Best case 0 ms worst case 0.0ms (period) sampling delay" diagnostic="">
+        <sourceReference href="../../CombinedETEF_Test_Impl_Instance.aaxl2#//@componentInstance.3"/>
+      </issues>
+    </contributors>
+    <contributors>
+      <sourceReference href="../../CombinedETEF_Test_Impl_Instance.aaxl2#//@componentInstance.3"/>
+      <values xsi:type="result:RealValue" value="10.0"/>
+      <values xsi:type="result:RealValue" value="10.0"/>
+      <values xsi:type="result:RealValue" value="10.0"/>
+      <values xsi:type="result:RealValue" value="10.0"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue" value="40.0"/>
+      <values xsi:type="result:RealValue" value="40.0"/>
+      <values xsi:type="result:RealValue" value="40.0"/>
+      <values xsi:type="result:StringValue" value="SPECIFIED"/>
+      <values xsi:type="result:StringValue" value="SPECIFIED"/>
+      <values xsi:type="result:StringValue" value="SYNCUNKNOWN"/>
+    </contributors>
+  </subResults>
+</result:Result>
+
+
+
+	'''
+
 }

--- a/org.osate.analysis.flows.tests/src/org/osate/analysis/flows/tests/FlowLatencyTest.xtend
+++ b/org.osate.analysis.flows.tests/src/org/osate/analysis/flows/tests/FlowLatencyTest.xtend
@@ -49,6 +49,11 @@ class FlowLatencyTest extends OsateTest {
 		val file = workspaceRoot.getFile(new Path(uri.toPlatformString(true)))
 		val actual = Files.readStreamIntoString(file.contents)
 		assertEquals('error', expected.trim, actual.trim)
+		val uriresult = URI.createURI(
+			resourceRoot + "/instances/reports/latency/pullprotocols_stub_i_Instance__latency_AS-MF-DL-EQ.result")
+		val fileresult = workspaceRoot.getFile(new Path(uriresult.toPlatformString(true)))
+		val actualresult = Files.readStreamIntoString(fileresult.contents)
+		assertEquals('error', expectedresult.trim, actualresult.trim)
 	}
 
 	val pullprotocolsText = '''
@@ -197,4 +202,335 @@ WARNING,Jitter of actual latency total 304.0..504.0ms exceeds expected end to en
 
 
 	'''
+
+	val expectedresult = '''
+<?xml version="1.0" encoding="ASCII"?>
+<result:Result xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:result="http://www.osate.org/result/Result" analysis="latencyreport">
+  <sourceReference href="../../pullprotocols_stub_i_Instance.aaxl2#/"/>
+  <subResults analysis="prot.XferOnly">
+    <sourceReference href="../../pullprotocols_stub_i_Instance.aaxl2#//@componentInstance.0/@endToEndFlow.0"/>
+    <values xsi:type="result:StringValue" value="Latency analysis for end-to-end flow 'prot.XferOnly' of system 'stub.i' with preference settings AS-MF-DL-EQ"/>
+    <values xsi:type="result:RealValue" value="304.0"/>
+    <values xsi:type="result:RealValue" value="504.0"/>
+    <values xsi:type="result:RealValue" value="4.0"/>
+    <values xsi:type="result:RealValue" value="4.0"/>
+    <values xsi:type="result:RealValue" value="300.0"/>
+    <values xsi:type="result:RealValue" value="300.0"/>
+    <contributors>
+      <sourceReference href="../../pullprotocols_stub_i_Instance.aaxl2#//@componentInstance.0/@componentInstance.0"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue" value="100.0"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:StringValue" value="FIRST_SAMPLED"/>
+      <values xsi:type="result:StringValue" value="FIRST_SAMPLED"/>
+      <values xsi:type="result:StringValue" value="SYNCUNKNOWN"/>
+      <issues issueType="INFO" message="Initial 100.0ms sampling latency not added" diagnostic="">
+        <sourceReference href="../../pullprotocols_stub_i_Instance.aaxl2#//@componentInstance.0/@componentInstance.0"/>
+      </issues>
+    </contributors>
+    <contributors>
+      <sourceReference href="../../pullprotocols_stub_i_Instance.aaxl2#//@componentInstance.0/@componentInstance.0"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue" value="100.0"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue" value="100.0"/>
+      <values xsi:type="result:StringValue" value="DEADLINE"/>
+      <values xsi:type="result:StringValue" value="UNKNOWN"/>
+      <values xsi:type="result:StringValue" value="SYNCUNKNOWN"/>
+    </contributors>
+    <contributors>
+      <sourceReference href="../../pullprotocols_stub_i_Instance.aaxl2#//@componentInstance.0/@connectionInstance.0"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue" value="100.0"/>
+      <values xsi:type="result:StringValue" value="UNKNOWN"/>
+      <values xsi:type="result:StringValue" value="UNKNOWN"/>
+      <values xsi:type="result:StringValue" value="SYNCUNKNOWN"/>
+    </contributors>
+    <contributors>
+      <sourceReference href="../../pullprotocols_stub_i_Instance.aaxl2#//@componentInstance.0/@componentInstance.1"/>
+      <values xsi:type="result:RealValue" value="100.0"/>
+      <values xsi:type="result:RealValue" value="100.0"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue" value="100.0"/>
+      <values xsi:type="result:RealValue" value="100.0"/>
+      <values xsi:type="result:RealValue" value="100.0"/>
+      <values xsi:type="result:RealValue" value="200.0"/>
+      <values xsi:type="result:StringValue" value="DELAYED"/>
+      <values xsi:type="result:StringValue" value="DELAYED"/>
+      <values xsi:type="result:StringValue" value="SYNCUNKNOWN"/>
+      <issues issueType="INFO" message="Min: Sampling period 100.0ms" diagnostic="">
+        <sourceReference href="../../pullprotocols_stub_i_Instance.aaxl2#//@componentInstance.0/@componentInstance.1"/>
+      </issues>
+      <issues issueType="INFO" message="Max: Sampling period 100.0ms" diagnostic="">
+        <sourceReference href="../../pullprotocols_stub_i_Instance.aaxl2#//@componentInstance.0/@componentInstance.1"/>
+      </issues>
+    </contributors>
+    <contributors>
+      <sourceReference href="../../pullprotocols_stub_i_Instance.aaxl2#//@componentInstance.0/@componentInstance.1"/>
+      <values xsi:type="result:RealValue" value="1.0"/>
+      <values xsi:type="result:RealValue" value="1.0"/>
+      <values xsi:type="result:RealValue" value="1.0"/>
+      <values xsi:type="result:RealValue" value="1.0"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue" value="101.0"/>
+      <values xsi:type="result:RealValue" value="101.0"/>
+      <values xsi:type="result:RealValue" value="201.0"/>
+      <values xsi:type="result:StringValue" value="SPECIFIED"/>
+      <values xsi:type="result:StringValue" value="SPECIFIED"/>
+      <values xsi:type="result:StringValue" value="SYNCUNKNOWN"/>
+    </contributors>
+    <contributors>
+      <sourceReference href="../../pullprotocols_stub_i_Instance.aaxl2#//@componentInstance.0/@connectionInstance.4"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue" value="101.0"/>
+      <values xsi:type="result:RealValue" value="101.0"/>
+      <values xsi:type="result:RealValue" value="201.0"/>
+      <values xsi:type="result:StringValue" value="UNKNOWN"/>
+      <values xsi:type="result:StringValue" value="UNKNOWN"/>
+      <values xsi:type="result:StringValue" value="SYNCUNKNOWN"/>
+    </contributors>
+    <contributors>
+      <sourceReference href="../../pullprotocols_stub_i_Instance.aaxl2#//@componentInstance.0/@componentInstance.0"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue" value="100.0"/>
+      <values xsi:type="result:RealValue" value="101.0"/>
+      <values xsi:type="result:RealValue" value="101.0"/>
+      <values xsi:type="result:RealValue" value="201.0"/>
+      <values xsi:type="result:StringValue" value="UNKNOWN"/>
+      <values xsi:type="result:StringValue" value="UNKNOWN"/>
+      <values xsi:type="result:StringValue" value="SYNCUNKNOWN"/>
+    </contributors>
+    <contributors>
+      <sourceReference href="../../pullprotocols_stub_i_Instance.aaxl2#//@componentInstance.0/@componentInstance.0"/>
+      <values xsi:type="result:RealValue" value="1.0"/>
+      <values xsi:type="result:RealValue" value="1.0"/>
+      <values xsi:type="result:RealValue" value="1.0"/>
+      <values xsi:type="result:RealValue" value="1.0"/>
+      <values xsi:type="result:RealValue" value="100.0"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue" value="102.0"/>
+      <values xsi:type="result:RealValue" value="102.0"/>
+      <values xsi:type="result:RealValue" value="202.0"/>
+      <values xsi:type="result:StringValue" value="SPECIFIED"/>
+      <values xsi:type="result:StringValue" value="SPECIFIED"/>
+      <values xsi:type="result:StringValue" value="SYNCUNKNOWN"/>
+    </contributors>
+    <contributors>
+      <sourceReference href="../../pullprotocols_stub_i_Instance.aaxl2#//@componentInstance.0/@connectionInstance.1"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue" value="102.0"/>
+      <values xsi:type="result:RealValue" value="102.0"/>
+      <values xsi:type="result:RealValue" value="202.0"/>
+      <values xsi:type="result:StringValue" value="UNKNOWN"/>
+      <values xsi:type="result:StringValue" value="UNKNOWN"/>
+      <values xsi:type="result:StringValue" value="SYNCUNKNOWN"/>
+    </contributors>
+    <contributors>
+      <sourceReference href="../../pullprotocols_stub_i_Instance.aaxl2#//@componentInstance.0/@componentInstance.1"/>
+      <values xsi:type="result:RealValue" value="100.0"/>
+      <values xsi:type="result:RealValue" value="100.0"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue" value="100.0"/>
+      <values xsi:type="result:RealValue" value="202.0"/>
+      <values xsi:type="result:RealValue" value="202.0"/>
+      <values xsi:type="result:RealValue" value="302.0"/>
+      <values xsi:type="result:StringValue" value="DELAYED"/>
+      <values xsi:type="result:StringValue" value="DELAYED"/>
+      <values xsi:type="result:StringValue" value="SYNCUNKNOWN"/>
+      <issues issueType="INFO" message="Min: Sampling period 100.0ms" diagnostic="">
+        <sourceReference href="../../pullprotocols_stub_i_Instance.aaxl2#//@componentInstance.0/@componentInstance.1"/>
+      </issues>
+      <issues issueType="INFO" message="Max: Sampling period 100.0ms" diagnostic="">
+        <sourceReference href="../../pullprotocols_stub_i_Instance.aaxl2#//@componentInstance.0/@componentInstance.1"/>
+      </issues>
+    </contributors>
+    <contributors>
+      <sourceReference href="../../pullprotocols_stub_i_Instance.aaxl2#//@componentInstance.0/@componentInstance.1"/>
+      <values xsi:type="result:RealValue" value="1.0"/>
+      <values xsi:type="result:RealValue" value="1.0"/>
+      <values xsi:type="result:RealValue" value="1.0"/>
+      <values xsi:type="result:RealValue" value="1.0"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue" value="203.0"/>
+      <values xsi:type="result:RealValue" value="203.0"/>
+      <values xsi:type="result:RealValue" value="303.0"/>
+      <values xsi:type="result:StringValue" value="SPECIFIED"/>
+      <values xsi:type="result:StringValue" value="SPECIFIED"/>
+      <values xsi:type="result:StringValue" value="SYNCUNKNOWN"/>
+    </contributors>
+    <contributors>
+      <sourceReference href="../../pullprotocols_stub_i_Instance.aaxl2#//@componentInstance.0/@connectionInstance.5"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue" value="203.0"/>
+      <values xsi:type="result:RealValue" value="203.0"/>
+      <values xsi:type="result:RealValue" value="303.0"/>
+      <values xsi:type="result:StringValue" value="UNKNOWN"/>
+      <values xsi:type="result:StringValue" value="UNKNOWN"/>
+      <values xsi:type="result:StringValue" value="SYNCUNKNOWN"/>
+    </contributors>
+    <contributors>
+      <sourceReference href="../../pullprotocols_stub_i_Instance.aaxl2#//@componentInstance.0/@componentInstance.0"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue" value="100.0"/>
+      <values xsi:type="result:RealValue" value="203.0"/>
+      <values xsi:type="result:RealValue" value="203.0"/>
+      <values xsi:type="result:RealValue" value="303.0"/>
+      <values xsi:type="result:StringValue" value="UNKNOWN"/>
+      <values xsi:type="result:StringValue" value="UNKNOWN"/>
+      <values xsi:type="result:StringValue" value="SYNCUNKNOWN"/>
+    </contributors>
+    <contributors>
+      <sourceReference href="../../pullprotocols_stub_i_Instance.aaxl2#//@componentInstance.0/@componentInstance.0"/>
+      <values xsi:type="result:RealValue" value="1.0"/>
+      <values xsi:type="result:RealValue" value="1.0"/>
+      <values xsi:type="result:RealValue" value="1.0"/>
+      <values xsi:type="result:RealValue" value="1.0"/>
+      <values xsi:type="result:RealValue" value="100.0"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue" value="204.0"/>
+      <values xsi:type="result:RealValue" value="204.0"/>
+      <values xsi:type="result:RealValue" value="304.0"/>
+      <values xsi:type="result:StringValue" value="SPECIFIED"/>
+      <values xsi:type="result:StringValue" value="SPECIFIED"/>
+      <values xsi:type="result:StringValue" value="SYNCUNKNOWN"/>
+    </contributors>
+    <contributors>
+      <sourceReference href="../../pullprotocols_stub_i_Instance.aaxl2#//@componentInstance.0/@connectionInstance.2"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue" value="204.0"/>
+      <values xsi:type="result:RealValue" value="204.0"/>
+      <values xsi:type="result:RealValue" value="304.0"/>
+      <values xsi:type="result:StringValue" value="UNKNOWN"/>
+      <values xsi:type="result:StringValue" value="UNKNOWN"/>
+      <values xsi:type="result:StringValue" value="SYNCUNKNOWN"/>
+    </contributors>
+    <contributors>
+      <sourceReference href="../../pullprotocols_stub_i_Instance.aaxl2#//@componentInstance.0/@componentInstance.1"/>
+      <values xsi:type="result:RealValue" value="100.0"/>
+      <values xsi:type="result:RealValue" value="100.0"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue" value="100.0"/>
+      <values xsi:type="result:RealValue" value="304.0"/>
+      <values xsi:type="result:RealValue" value="304.0"/>
+      <values xsi:type="result:RealValue" value="404.0"/>
+      <values xsi:type="result:StringValue" value="DELAYED"/>
+      <values xsi:type="result:StringValue" value="DELAYED"/>
+      <values xsi:type="result:StringValue" value="SYNCUNKNOWN"/>
+      <issues issueType="INFO" message="Min: Sampling period 100.0ms" diagnostic="">
+        <sourceReference href="../../pullprotocols_stub_i_Instance.aaxl2#//@componentInstance.0/@componentInstance.1"/>
+      </issues>
+      <issues issueType="INFO" message="Max: Sampling period 100.0ms" diagnostic="">
+        <sourceReference href="../../pullprotocols_stub_i_Instance.aaxl2#//@componentInstance.0/@componentInstance.1"/>
+      </issues>
+    </contributors>
+    <contributors>
+      <sourceReference href="../../pullprotocols_stub_i_Instance.aaxl2#//@componentInstance.0/@componentInstance.1"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue" value="100.0"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue"/>
+      <values xsi:type="result:RealValue" value="304.0"/>
+      <values xsi:type="result:RealValue" value="304.0"/>
+      <values xsi:type="result:RealValue" value="504.0"/>
+      <values xsi:type="result:StringValue" value="DEADLINE"/>
+      <values xsi:type="result:StringValue" value="UNKNOWN"/>
+      <values xsi:type="result:StringValue" value="SYNCUNKNOWN"/>
+    </contributors>
+  </subResults>
+</result:Result>
+
+
+
+	'''
+
 }

--- a/org.osate.analysis.flows/META-INF/MANIFEST.MF
+++ b/org.osate.analysis.flows/META-INF/MANIFEST.MF
@@ -17,5 +17,6 @@ Require-Bundle: org.osate.aadl2,
  org.osate.aadl2.modelsupport,
  org.osate.ui;visibility:=reexport,
  org.osate.xtext.aadl2.properties;bundle-version="1.0.0",
- org.osate.contribution.sei
+ org.osate.contribution.sei,
+ org.osate.results;bundle-version="1.0.0"
 Eclipse-LazyStart: true

--- a/org.osate.analysis.flows/src/org/osate/analysis/flows/FlowLatencyAnalysisSwitch.java
+++ b/org.osate.analysis.flows/src/org/osate/analysis/flows/FlowLatencyAnalysisSwitch.java
@@ -71,6 +71,7 @@ public class FlowLatencyAnalysisSwitch extends AadlProcessingSwitchWithProgress 
 //		return this.report;
 //	}
 
+	@Override
 	protected final void initSwitches() {
 		/* here we are creating the connection checking switches */
 
@@ -78,6 +79,7 @@ public class FlowLatencyAnalysisSwitch extends AadlProcessingSwitchWithProgress 
 			/**
 			 * check flow latency
 			 */
+			@Override
 			public String caseComponentInstance(final ComponentInstance ci) {
 //				monitor.subTask("Checking flows in " + ci.getName());
 ////				processEList(ci.getEndToEndFlows());
@@ -85,6 +87,7 @@ public class FlowLatencyAnalysisSwitch extends AadlProcessingSwitchWithProgress 
 				return DONE;
 			}
 
+			@Override
 			public String caseEndToEndFlowInstance(final EndToEndFlowInstance etef) {
 				LatencyReportEntry entry;
 
@@ -96,6 +99,7 @@ public class FlowLatencyAnalysisSwitch extends AadlProcessingSwitchWithProgress 
 				for (FlowElementInstance fei : etef.getFlowElements()) {
 					FlowLatencyLogic.mapFlowElementInstance(etef, fei, entry);
 				}
+				entry.finalizeReportEntry();
 				report.addEntry(entry);
 				return DONE;
 			}

--- a/org.osate.analysis.flows/src/org/osate/analysis/flows/handlers/CheckFlowLatency.java
+++ b/org.osate.analysis.flows/src/org/osate/analysis/flows/handlers/CheckFlowLatency.java
@@ -101,7 +101,7 @@ public final class CheckFlowLatency extends AbstractInstanceOrDeclarativeModelRe
 			SystemInstance root = latreport.getRootinstance();
 
 			URI latencyURI = EcoreUtil.getURI(root).trimFragment().trimSegments(1).appendSegment("reports")
-					.appendSegment("latency").appendSegment(root.getName() + ".results");
+					.appendSegment("latency").appendSegment(root.getName() + ".latency");
 			AadlUtil.makeSureFoldersExist(new Path(latencyURI.toPlatformString(true)));
 			URI newuri = OsateResourceUtil.saveEMFModel(results, latencyURI, root);
 		}

--- a/org.osate.analysis.flows/src/org/osate/analysis/flows/handlers/CheckFlowLatency.java
+++ b/org.osate.analysis.flows/src/org/osate/analysis/flows/handlers/CheckFlowLatency.java
@@ -99,9 +99,11 @@ public final class CheckFlowLatency extends AbstractInstanceOrDeclarativeModelRe
 
 			Result results = latreport.genResult();
 			SystemInstance root = latreport.getRootinstance();
-
-			URI latencyURI = EcoreUtil.getURI(root).trimFragment().trimSegments(1).appendSegment("reports")
-					.appendSegment("latency").appendSegment(root.getName() + ".result");
+			URI rootURI = EcoreUtil.getURI(root).trimFragment().trimFileExtension();
+			String rootname = rootURI.lastSegment();
+			URI latencyURI = rootURI.trimFragment().trimSegments(1).appendSegment("reports")
+					.appendSegment("latency")
+					.appendSegment(rootname + "__latency_" + latreport.getPreferencesSuffix() + ".result");
 			AadlUtil.makeSureFoldersExist(new Path(latencyURI.toPlatformString(true)));
 			URI newuri = OsateResourceUtil.saveEMFModel(results, latencyURI, root);
 		}

--- a/org.osate.analysis.flows/src/org/osate/analysis/flows/handlers/CheckFlowLatency.java
+++ b/org.osate.analysis.flows/src/org/osate/analysis/flows/handlers/CheckFlowLatency.java
@@ -101,7 +101,7 @@ public final class CheckFlowLatency extends AbstractInstanceOrDeclarativeModelRe
 			SystemInstance root = latreport.getRootinstance();
 
 			URI latencyURI = EcoreUtil.getURI(root).trimFragment().trimSegments(1).appendSegment("reports")
-					.appendSegment("latency").appendSegment(root.getName() + ".latency");
+					.appendSegment("latency").appendSegment(root.getName() + ".result");
 			AadlUtil.makeSureFoldersExist(new Path(latencyURI.toPlatformString(true)));
 			URI newuri = OsateResourceUtil.saveEMFModel(results, latencyURI, root);
 		}

--- a/org.osate.analysis.flows/src/org/osate/analysis/flows/handlers/CheckFlowLatency.java
+++ b/org.osate.analysis.flows/src/org/osate/analysis/flows/handlers/CheckFlowLatency.java
@@ -55,7 +55,7 @@ import org.osate.analysis.flows.model.LatencyReport;
 import org.osate.analysis.flows.reporting.exporters.CsvExport;
 import org.osate.analysis.flows.reporting.exporters.ExcelExport;
 import org.osate.analysis.flows.reporting.model.Report;
-import org.osate.results.Results;
+import org.osate.result.Result;
 import org.osate.ui.dialogs.Dialog;
 import org.osate.ui.handlers.AbstractInstanceOrDeclarativeModelReadOnlyHandler;
 
@@ -97,7 +97,7 @@ public final class CheckFlowLatency extends AbstractInstanceOrDeclarativeModelRe
 			ExcelExport excelExport = new ExcelExport(report);
 			excelExport.save();
 
-			Results results = latreport.genResults();
+			Result results = latreport.genResult();
 			SystemInstance root = latreport.getRootinstance();
 
 			URI latencyURI = EcoreUtil.getURI(root).trimFragment().trimSegments(1).appendSegment("reports")

--- a/org.osate.analysis.flows/src/org/osate/analysis/flows/handlers/CheckFlowLatency.java
+++ b/org.osate.analysis.flows/src/org/osate/analysis/flows/handlers/CheckFlowLatency.java
@@ -40,16 +40,22 @@
 package org.osate.analysis.flows.handlers;
 
 import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.Path;
+import org.eclipse.emf.common.util.URI;
+import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.osate.aadl2.Element;
 import org.osate.aadl2.NamedElement;
 import org.osate.aadl2.instance.SystemInstance;
 import org.osate.aadl2.instance.SystemOperationMode;
 import org.osate.aadl2.modelsupport.errorreporting.AnalysisErrorReporterManager;
+import org.osate.aadl2.modelsupport.resources.OsateResourceUtil;
+import org.osate.aadl2.modelsupport.util.AadlUtil;
 import org.osate.analysis.flows.FlowLatencyAnalysisSwitch;
 import org.osate.analysis.flows.model.LatencyReport;
 import org.osate.analysis.flows.reporting.exporters.CsvExport;
 import org.osate.analysis.flows.reporting.exporters.ExcelExport;
 import org.osate.analysis.flows.reporting.model.Report;
+import org.osate.results.Results;
 import org.osate.ui.dialogs.Dialog;
 import org.osate.ui.handlers.AbstractInstanceOrDeclarativeModelReadOnlyHandler;
 
@@ -90,6 +96,14 @@ public final class CheckFlowLatency extends AbstractInstanceOrDeclarativeModelRe
 			csvExport.save();
 			ExcelExport excelExport = new ExcelExport(report);
 			excelExport.save();
+
+			Results results = latreport.genResults();
+			SystemInstance root = latreport.getRootinstance();
+
+			URI latencyURI = EcoreUtil.getURI(root).trimFragment().trimSegments(1).appendSegment("reports")
+					.appendSegment("latency").appendSegment(root.getName() + ".results");
+			AadlUtil.makeSureFoldersExist(new Path(latencyURI.toPlatformString(true)));
+			URI newuri = OsateResourceUtil.saveEMFModel(results, latencyURI, root);
 		}
 		return true;
 	};
@@ -121,9 +135,9 @@ public final class CheckFlowLatency extends AbstractInstanceOrDeclarativeModelRe
 
 	/**
 	 * Invoke the analysis but return the report object rather than writing it to disk.
-	 * 
+	 *
 	 * @param monitor The progress monitor to use
-	 * @param errManager [Optional] The error manager to use, or null if one should be created 
+	 * @param errManager [Optional] The error manager to use, or null if one should be created
 	 * @param root The root system instance
 	 * @param som The mode to run the analysis in
 	 * @return A populated report.

--- a/org.osate.analysis.flows/src/org/osate/analysis/flows/model/LatencyContributor.java
+++ b/org.osate.analysis.flows/src/org/osate/analysis/flows/model/LatencyContributor.java
@@ -1,7 +1,9 @@
 package org.osate.analysis.flows.model;
 
 
-import static org.osate.results.util.ResultsUtil.createIssue;
+import static org.osate.result.util.ResultUtil.addRealValue;
+import static org.osate.result.util.ResultUtil.addStringValue;
+import static org.osate.result.util.ResultUtil.createIssue;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -13,10 +15,10 @@ import org.osate.analysis.flows.FlowLatencyUtil;
 import org.osate.analysis.flows.preferences.Values;
 import org.osate.analysis.flows.reporting.model.Line;
 import org.osate.analysis.flows.reporting.model.ReportSeverity;
-import org.osate.results.ResultContributor;
-import org.osate.results.ResultIssue;
-import org.osate.results.ResultIssueType;
-import org.osate.results.ResultsFactory;
+import org.osate.result.Contributor;
+import org.osate.result.Issue;
+import org.osate.result.IssueType;
+import org.osate.result.ResultFactory;
 
 /**
  * A latency Contributor represents something in the flow
@@ -90,7 +92,7 @@ public abstract class LatencyContributor {
 	 */
 	private double samplingPeriod;
 
-	List<ResultIssue> issues;
+	List<Issue> issues;
 
 	/**
 	 * Sampling of incoming communication is synchronous
@@ -135,49 +137,49 @@ public abstract class LatencyContributor {
 		this.partitionOffset = 0.0;
 		this.partitionDuration = 0.0;
 		this.subContributors = new ArrayList<LatencyContributor>();
-		this.issues = new ArrayList<ResultIssue>();
+		this.issues = new ArrayList<Issue>();
 		this.maxSubtotal = 0.0;
 		this.minSubtotal = 0.0;
 	}
 
-	protected List<ResultIssue> getReportedIssues() {
+	protected List<Issue> getReportedIssues() {
 		return this.issues;
 	}
 
 	public void reportError(String str) {
-		issues.add(createIssue(str, this.relatedElement, ResultIssueType.ERROR, ""));
+		issues.add(createIssue(str, this.relatedElement, IssueType.ERROR, ""));
 	}
 
 	public void reportSuccess(String str) {
-		issues.add(createIssue(str, this.relatedElement, ResultIssueType.SUCCESS, ""));
+		issues.add(createIssue(str, this.relatedElement, IssueType.SUCCESS, ""));
 	}
 
 	public void reportInfo(String str) {
-		issues.add(createIssue(str, this.relatedElement, ResultIssueType.INFO, ""));
+		issues.add(createIssue(str, this.relatedElement, IssueType.INFO, ""));
 	}
 
 	public void reportWarning(String str) {
-		issues.add(createIssue(str, this.relatedElement, ResultIssueType.WARNING, ""));
+		issues.add(createIssue(str, this.relatedElement, IssueType.WARNING, ""));
 	}
 
 	public void reportError(boolean doMaximum, String str) {
 		issues.add(createIssue(FlowLatencyUtil.getMinMaxLabel(doMaximum) + str,
-				this.relatedElement, ResultIssueType.ERROR, ""));
+				this.relatedElement, IssueType.ERROR, ""));
 	}
 
 	public void reportSuccess(boolean doMaximum, String str) {
 		issues.add(createIssue(FlowLatencyUtil.getMinMaxLabel(doMaximum) + str,
-				this.relatedElement, ResultIssueType.SUCCESS, ""));
+				this.relatedElement, IssueType.SUCCESS, ""));
 	}
 
 	public void reportInfo(boolean doMaximum, String str) {
 		issues.add(createIssue(FlowLatencyUtil.getMinMaxLabel(doMaximum) + str,
-				this.relatedElement, ResultIssueType.INFO, ""));
+				this.relatedElement, IssueType.INFO, ""));
 	}
 
 	public void reportWarning(boolean doMaximum, String str) {
 		issues.add(createIssue(FlowLatencyUtil.getMinMaxLabel(doMaximum) + str,
-				this.relatedElement, ResultIssueType.WARNING, ""));
+				this.relatedElement, IssueType.WARNING, ""));
 	}
 
 	public void reportErrorOnce(boolean doMaximum, String str) {
@@ -571,61 +573,48 @@ public abstract class LatencyContributor {
 	}
 
 	public void generateMarkers(AnalysisErrorReporterManager errManager) {
-		List<ResultIssue> doIssues = this.getReportedIssues();
-		for (ResultIssue reportedCell : doIssues) {
-			if (reportedCell.getIssueType() == ResultIssueType.INFO) {
+		List<Issue> doIssues = this.getReportedIssues();
+		for (Issue reportedCell : doIssues) {
+			if (reportedCell.getIssueType() == IssueType.INFO) {
 				errManager.info(this.relatedElement, reportedCell.getMessage());
-			} else if (reportedCell.getIssueType() == ResultIssueType.SUCCESS) {
+			} else if (reportedCell.getIssueType() == IssueType.SUCCESS) {
 				errManager.info(this.relatedElement, getRelatedObjectLabel() + reportedCell.getMessage());
-			} else if (reportedCell.getIssueType() == ResultIssueType.WARNING) {
+			} else if (reportedCell.getIssueType() == IssueType.WARNING) {
 				errManager.warning(this.relatedElement, getRelatedObjectLabel() + reportedCell.getMessage());
-			} else if (reportedCell.getIssueType() == ResultIssueType.ERROR) {
+			} else if (reportedCell.getIssueType() == IssueType.ERROR) {
 				errManager.error(this.relatedElement, getRelatedObjectLabel() + reportedCell.getMessage());
 			}
 		}
 	}
 
-	public ResultContributor genResults() {
-		return genResults(0);
+	public Contributor genResult() {
+		return genResult(0);
 	}
 
-	public ResultContributor genResults(int level) {
+	public Contributor genResult(int level) {
 
-		ResultContributor result = ResultsFactory.eINSTANCE.createResultContributor();
-		result.setTarget(relatedElement);
+		Contributor result = ResultFactory.eINSTANCE.createContributor();
+		result.setSourceReference(relatedElement);
 		result.getIssues().addAll(issues);
-		result.getValues().add(minValue);
-		result.getValues().add(maxValue);
-		result.getValues().add(expectedMin);
-		result.getValues().add(expectedMax);
-		result.getValues().add(immediateDeadline);
-		result.getValues().add(partitionOffset);
-		result.getValues().add(partitionDuration);
-		result.getValues().add(samplingPeriod);
-		result.getValues().add(minSubtotal);
-		result.getValues().add(maxSubtotal);
-		result.getValues().add(worstCaseMethod.name());
-		result.getValues().add(bestCaseMethod.name());
-		result.getValues().add(isSynchronized.name());
-//		UnitLiteral msliteral = GetProperties.getMSUnitLiteral(relatedElement);
-//		addDataValue(result, "minValue", minValue, msliteral);
-//		addDataValue(result, "maxValue", maxValue, msliteral);
-//		addDataValue(result, "expectedMin", expectedMin, msliteral);
-//		addDataValue(result, "expectedMax", expectedMax, msliteral);
-//		addDataValue(result, "immediateDeadline", immediateDeadline, msliteral);
-//		addDataValue(result, "partitionOffset", partitionOffset, msliteral);
-//		addDataValue(result, "partitionDuration", partitionDuration, msliteral);
-//		addDataValue(result, "samplingPeriod", samplingPeriod, msliteral);
-//		addDataValue(result, "minSubtotal", minSubtotal, msliteral);
-//		addDataValue(result, "maxSubtotal", maxSubtotal, msliteral);
-//		addStringValue(result, "worstCaseMethod", worstCaseMethod.name());
-//		addStringValue(result, "bestCaseMethod", bestCaseMethod.name());
-//		addStringValue(result, "isSynchronized", isSynchronized.name());
+		addRealValue(result, minValue);
+		addRealValue(result, maxValue);
+		addRealValue(result, expectedMin);
+		addRealValue(result, expectedMax);
+		addRealValue(result, immediateDeadline);
+		addRealValue(result, partitionOffset);
+		addRealValue(result, partitionDuration);
+		addRealValue(result, samplingPeriod);
+		addRealValue(result, minSubtotal);
+		addRealValue(result, minSubtotal);
+		addRealValue(result, maxSubtotal);
+		addStringValue(result,worstCaseMethod.name());
+		addStringValue(result, bestCaseMethod.name());
+		addStringValue(result,isSynchronized.name());
 		/**
 		 * We also add the lines of all the sub-contributors.
 		 */
 		for (LatencyContributor lc : this.subContributors) {
-			result.getSubcontributor().add(lc.genResults(level + 1));
+			result.getSubContributors().add(lc.genResult(level + 1));
 		}
 		return result;
 	}

--- a/org.osate.analysis.flows/src/org/osate/analysis/flows/model/LatencyReport.java
+++ b/org.osate.analysis.flows/src/org/osate/analysis/flows/model/LatencyReport.java
@@ -8,13 +8,15 @@ import org.osate.aadl2.modelsupport.errorreporting.AnalysisErrorReporterManager;
 import org.osate.analysis.flows.preferences.Values;
 import org.osate.analysis.flows.reporting.model.Report;
 import org.osate.analysis.flows.reporting.model.Report.ReportType;
+import org.osate.results.Results;
+import org.osate.results.util.ResultsUtil;
 
 /**
  * The LatencyReport class represents the generic class
  * produced by the latency analysis. It contains several
  * LatencyReportEntry, each one representing
  * an end to end flow latency.
- * 
+ *
  * @author julien
  *
  */
@@ -35,6 +37,10 @@ public class LatencyReport {
 
 	public void setName(String n) {
 		this.name = n;
+	}
+
+	public SystemInstance getRootinstance() {
+		return this.relatedInstance;
 	}
 
 	public List<LatencyReportEntry> getEntries() {
@@ -62,5 +68,15 @@ public class LatencyReport {
 		}
 
 		return genericReport;
+	}
+
+	public Results genResults() {
+
+		Results latencyReports = ResultsUtil.createResults(this.name,
+				this.relatedInstance);
+		for (LatencyReportEntry re : entries) {
+			latencyReports.getResults().add(re.genResults());
+		}
+		return latencyReports;
 	}
 }

--- a/org.osate.analysis.flows/src/org/osate/analysis/flows/model/LatencyReport.java
+++ b/org.osate.analysis.flows/src/org/osate/analysis/flows/model/LatencyReport.java
@@ -8,8 +8,8 @@ import org.osate.aadl2.modelsupport.errorreporting.AnalysisErrorReporterManager;
 import org.osate.analysis.flows.preferences.Values;
 import org.osate.analysis.flows.reporting.model.Report;
 import org.osate.analysis.flows.reporting.model.Report.ReportType;
-import org.osate.results.Results;
-import org.osate.results.util.ResultsUtil;
+import org.osate.result.Result;
+import org.osate.result.util.ResultUtil;
 
 /**
  * The LatencyReport class represents the generic class
@@ -70,12 +70,12 @@ public class LatencyReport {
 		return genericReport;
 	}
 
-	public Results genResults() {
+	public Result genResult() {
 
-		Results latencyReports = ResultsUtil.createResults(this.name,
+		Result latencyReports = ResultUtil.createResult(this.name,
 				this.relatedInstance);
 		for (LatencyReportEntry re : entries) {
-			latencyReports.getResults().add(re.genResults());
+			latencyReports.getSubResults().add(re.genResult());
 		}
 		return latencyReports;
 	}

--- a/org.osate.analysis.flows/src/org/osate/analysis/flows/reporting/exporters/ExcelExport.java
+++ b/org.osate.analysis.flows/src/org/osate/analysis/flows/reporting/exporters/ExcelExport.java
@@ -3,6 +3,16 @@ package org.osate.analysis.flows.reporting.exporters;
 import java.io.IOException;
 import java.util.Locale;
 
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.CoreException;
+import org.osate.aadl2.modelsupport.util.AadlUtil;
+import org.osate.analysis.flows.reporting.model.Line;
+import org.osate.analysis.flows.reporting.model.Report;
+import org.osate.analysis.flows.reporting.model.ReportedCell;
+import org.osate.analysis.flows.reporting.model.Section;
+
 import jxl.Workbook;
 import jxl.WorkbookSettings;
 import jxl.format.Colour;
@@ -14,16 +24,6 @@ import jxl.write.WritableSheet;
 import jxl.write.WritableWorkbook;
 import jxl.write.WriteException;
 import jxl.write.biff.RowsExceededException;
-
-import org.eclipse.core.resources.IFile;
-import org.eclipse.core.resources.IResource;
-import org.eclipse.core.resources.ResourcesPlugin;
-import org.eclipse.core.runtime.CoreException;
-import org.osate.aadl2.modelsupport.util.AadlUtil;
-import org.osate.analysis.flows.reporting.model.Line;
-import org.osate.analysis.flows.reporting.model.Report;
-import org.osate.analysis.flows.reporting.model.ReportedCell;
-import org.osate.analysis.flows.reporting.model.Section;
 
 public class ExcelExport extends GenericExport {
 	private WritableCellFormat normal;
@@ -111,14 +111,15 @@ public class ExcelExport extends GenericExport {
 			return warningBold;
 		case SUCCESS:
 			return successBold;
-		case HEADER:
-			return normalBold;
-		default:
+		case INFO:
 			return normal;
+		default:
+			return normalBold;
 		}
 
 	}
 
+	@Override
 	public void save() {
 
 		WritableSheet excelSheet;

--- a/org.osate.analysis.flows/src/org/osate/analysis/flows/reporting/model/Line.java
+++ b/org.osate.analysis.flows/src/org/osate/analysis/flows/reporting/model/Line.java
@@ -3,6 +3,9 @@ package org.osate.analysis.flows.reporting.model;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.osate.results.ResultIssue;
+import org.osate.results.ResultIssueType;
+
 public class Line {
 	private List<ReportedCell> content;
 	private ReportSeverity type;
@@ -25,23 +28,25 @@ public class Line {
 	}
 
 	public void addError(String s) {
-		this.content.add(new ReportedCell(ReportSeverity.ERROR, s));
+		this.content.add(new ReportedCell(ResultIssueType.ERROR, s));
 	}
 
 	public void addSuccess(String s) {
-		this.content.add(new ReportedCell(ReportSeverity.SUCCESS, s));
+		this.content.add(new ReportedCell(ResultIssueType.SUCCESS, s));
 	}
 
 	public void addHeaderContent(String s) {
-		this.content.add(new ReportedCell(ReportSeverity.HEADER, s));
+		this.content.add(new ReportedCell(ResultIssueType.TBD, s));
 	}
 
 	public void addCell(ReportedCell cell) {
 		this.content.add(cell);
 	}
 
-	public void addCells(List<ReportedCell> cells) {
-		this.content.addAll(cells);
+	public void addCells(List<ResultIssue> cells) {
+		for (ResultIssue resultIssue : cells) {
+			this.content.add(new ReportedCell(resultIssue.getIssueType(), resultIssue.getMessage()));
+		}
 	}
 
 	public List<ReportedCell> getContent() {

--- a/org.osate.analysis.flows/src/org/osate/analysis/flows/reporting/model/Line.java
+++ b/org.osate.analysis.flows/src/org/osate/analysis/flows/reporting/model/Line.java
@@ -3,8 +3,8 @@ package org.osate.analysis.flows.reporting.model;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.osate.results.ResultIssue;
-import org.osate.results.ResultIssueType;
+import org.osate.result.Issue;
+import org.osate.result.IssueType;
 
 public class Line {
 	private List<ReportedCell> content;
@@ -28,23 +28,23 @@ public class Line {
 	}
 
 	public void addError(String s) {
-		this.content.add(new ReportedCell(ResultIssueType.ERROR, s));
+		this.content.add(new ReportedCell(IssueType.ERROR, s));
 	}
 
 	public void addSuccess(String s) {
-		this.content.add(new ReportedCell(ResultIssueType.SUCCESS, s));
+		this.content.add(new ReportedCell(IssueType.SUCCESS, s));
 	}
 
 	public void addHeaderContent(String s) {
-		this.content.add(new ReportedCell(ResultIssueType.TBD, s));
+		this.content.add(new ReportedCell(IssueType.NONE, s));
 	}
 
 	public void addCell(ReportedCell cell) {
 		this.content.add(cell);
 	}
 
-	public void addCells(List<ResultIssue> cells) {
-		for (ResultIssue resultIssue : cells) {
+	public void addCells(List<Issue> cells) {
+		for (Issue resultIssue : cells) {
 			this.content.add(new ReportedCell(resultIssue.getIssueType(), resultIssue.getMessage()));
 		}
 	}

--- a/org.osate.analysis.flows/src/org/osate/analysis/flows/reporting/model/ReportedCell.java
+++ b/org.osate.analysis.flows/src/org/osate/analysis/flows/reporting/model/ReportedCell.java
@@ -1,18 +1,20 @@
 package org.osate.analysis.flows.reporting.model;
 
+import org.osate.results.ResultIssueType;
+
 public class ReportedCell {
 
 	private String msg;
-	private ReportSeverity severity;
+	private ResultIssueType severity;
 
-	public ReportedCell(ReportSeverity sev, String msg) {
+	public ReportedCell(ResultIssueType sev, String msg) {
 		this.msg = msg;
 		this.severity = sev;
 	}
 
 	public ReportedCell(String msg) {
 		this.msg = msg;
-		this.severity = ReportSeverity.INFO;
+		this.severity = ResultIssueType.INFO;
 	}
 
 	public String getMessage() {
@@ -23,24 +25,24 @@ public class ReportedCell {
 		this.msg = msg;
 	}
 
-	public ReportSeverity getSeverity() {
+	public ResultIssueType getSeverity() {
 		return this.severity;
 	}
 
 	public boolean isError() {
-		return this.severity.equals(ReportSeverity.ERROR);
+		return this.severity.equals(ResultIssueType.ERROR);
 	}
 
 	public boolean isWarning() {
-		return this.severity.equals(ReportSeverity.WARNING);
+		return this.severity.equals(ResultIssueType.WARNING);
 	}
 
 	public boolean isSuccess() {
-		return this.severity.equals(ReportSeverity.SUCCESS);
+		return this.severity.equals(ResultIssueType.SUCCESS);
 	}
 
 	public boolean isInfo() {
-		return this.severity.equals(ReportSeverity.INFO);
+		return this.severity.equals(ResultIssueType.INFO);
 	}
 
 }

--- a/org.osate.analysis.flows/src/org/osate/analysis/flows/reporting/model/ReportedCell.java
+++ b/org.osate.analysis.flows/src/org/osate/analysis/flows/reporting/model/ReportedCell.java
@@ -1,20 +1,20 @@
 package org.osate.analysis.flows.reporting.model;
 
-import org.osate.results.ResultIssueType;
+import org.osate.result.IssueType;
 
 public class ReportedCell {
 
 	private String msg;
-	private ResultIssueType severity;
+	private IssueType severity;
 
-	public ReportedCell(ResultIssueType sev, String msg) {
+	public ReportedCell(IssueType sev, String msg) {
 		this.msg = msg;
 		this.severity = sev;
 	}
 
 	public ReportedCell(String msg) {
 		this.msg = msg;
-		this.severity = ResultIssueType.INFO;
+		this.severity = IssueType.INFO;
 	}
 
 	public String getMessage() {
@@ -25,24 +25,24 @@ public class ReportedCell {
 		this.msg = msg;
 	}
 
-	public ResultIssueType getSeverity() {
+	public IssueType getSeverity() {
 		return this.severity;
 	}
 
 	public boolean isError() {
-		return this.severity.equals(ResultIssueType.ERROR);
+		return this.severity.equals(IssueType.ERROR);
 	}
 
 	public boolean isWarning() {
-		return this.severity.equals(ResultIssueType.WARNING);
+		return this.severity.equals(IssueType.WARNING);
 	}
 
 	public boolean isSuccess() {
-		return this.severity.equals(ResultIssueType.SUCCESS);
+		return this.severity.equals(IssueType.SUCCESS);
 	}
 
 	public boolean isInfo() {
-		return this.severity.equals(ResultIssueType.INFO);
+		return this.severity.equals(IssueType.INFO);
 	}
 
 }


### PR DESCRIPTION
Added saving of latency results in new result format.
Updated two test methods to compare the content of the generated results.
Depends on pull request osate/osate2-core#899 for issue osate/osate2-core#898
Also uses resolution of issue osate/osate2-core#897